### PR TITLE
Dump extracted datapackages to S3

### DIFF
--- a/datapackage_pipelines_od4tj/generator.py
+++ b/datapackage_pipelines_od4tj/generator.py
@@ -124,9 +124,10 @@ class Generator(GeneratorBase):
                 },
             ])
             pipeline.append({
-                'run': 'dump.to_path',
+                'run': 'aws.dump.to_s3',
                 'parameters': {
-                    'out-path': '/tmp/od4tj/'+pipeline_id
+                    'bucket': 'od4tj',
+                    'path': 'crd_iv_datapackages/{}_{}'.format(entity_slug, item['year'])
                 }
             })
             yield pipeline_id, {

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ INSTALL_REQUIRES = [
     'datapackage-pipelines',
     'psycopg2',
     'tabula-py',
+    'datapackage-pipelines-aws',
 ]
 TESTS_REQUIRES = [
     'tox',


### PR DESCRIPTION
This pull request fixes #6.

The code assumes that the AWS credentials [as described here](http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html) are available in the environment. 

The code also expects the specified account to have a preexistent S3 bucket named 'od4tj'

.