### PR TITLE
Extract title from whole table

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,38 +6,5 @@ Currently we expect the data source to be PDF tables. Please open an issue to re
 
 ## How to contribute a new dataset
 
-1. Download the file (but write down the download link)
-
-2. Open the PDF in your local installation of  [Tabula](http://tabula.technology/).
-   Alternatively, you can use the online version at [https://tabula.openknowledge.io](https://tabula.openknowledge.io)
-
-3. your stage 5 & 6
-Email us (or open an issue) with the following information:
-Download link
-Company
-Year
-Dimension
-Column mapping
-Currency & units (e.g. millions)
-
-
-3. Select the table and twitch settings (e.g. `stream/lattice`) until the parsed table contains all the information it should.
-
-    Do not worry if the parsed table contains extra rows: e.g. header row is split into multiple rows; there are category rows that doesn't contain data. Those will be eliminated in the pipeline.
-
-    The most important aspect is for the parsed table to contain all the selected information.
-
-4. Export the selection dimensions by following these steps in Tabula:
-
-  Export -> JSON (dimensions) -> Copy to clipboard -> Paste where you need it
-  
-5. Open an Issue in Github and add all this information:
- - Download link
- - Company
- - Year
- - Dimension
- - Column mapping
- - Currency & units (e.g. millions)
- 
- And any other information that might be relevant
-
+To contribute with a new dataset to our pipeline [open a new issue](https://github.com/okfn/datapackage_pipelines_od4tj/issues/new) and follow the instructions there.
+Once you replaced the values with the info specific to your dataset press "Submit new issue".

--- a/datapackage_pipelines_od4tj/generator.py
+++ b/datapackage_pipelines_od4tj/generator.py
@@ -42,16 +42,14 @@ class Generator(GeneratorBase):
             ]
             for input in item['inputs']:
                 if input['kind'] == 'pdf':
-                    for dimension in input['parameters']['dimensions']:
-                        parameters = {}
-                        parameters['dimensions'] = dimension
-                        parameters['transpose'] = input.get('transpose', False)
-                        parameters['url'] = input['url']
-                        parameters['headers'] = item['model']['headers']
-                        pipeline.append({
-                            'run': 'od4tj.tabula_resource',
-                            'parameters': parameters
-                        })
+                    parameters = input['parameters']
+                    parameters['transpose'] = input.get('transpose', False)
+                    parameters['url'] = input['url']
+                    parameters['headers'] = item['model']['headers']
+                    pipeline.append({
+                        'run': 'od4tj.tabula_resource',
+                        'parameters': parameters
+                    })
             pipeline.append({
                 'run': 'concatenate',
                 'parameters': {
@@ -61,8 +59,7 @@ class Generator(GeneratorBase):
                     },
                     'fields': dict(
                         (h['mapping'], [])
-                        for h in (item['model']['headers'] +
-                                  [{'mapping': 'url'}, {'mapping': 'page'}])
+                        for h in (item['model']['headers'] + [{'mapping': 'url'}])
                     )
                 }
             })

--- a/datapackage_pipelines_od4tj/pipelines/crd-iv/bnp_paribas/od4tj.source-spec.yaml
+++ b/datapackage_pipelines_od4tj/pipelines/crd-iv/bnp_paribas/od4tj.source-spec.yaml
@@ -7,28 +7,26 @@
       parameters:
         dimensions: [
                         {
-                            "extraction_method": "stream",
-                            "height": 486.6381307983399,
                             "page": 488,
-                            "selection_id": "Y1500448029091",
-                            "spec_index": 0,
-                            "width": 235.1340203857422,
-                            "x1": 68.08469261169434,
-                            "x2": 303.2187129974365,
-                            "y1": 190.86036781311037,
-                            "y2": 677.4984986114503
+                            "extraction_method": "lattice",
+                            "selection_id": "J1503436112051",
+                            "x1": 69.9449301147461,
+                            "x2": 299.8702854919434,
+                            "y1": 161.45931407515974,
+                            "y2": 677.8612449223277,
+                            "width": 229.92535537719726,
+                            "height": 516.401930847168
                         },
                         {
-                            "extraction_method": "stream",
-                            "height": 252.24820541381837,
                             "page": 488,
-                            "selection_id": "P1500448040115",
-                            "spec_index": 1,
-                            "width": 235.8781153869629,
-                            "x1": 319.588803024292,
-                            "x2": 555.4669184112549,
-                            "y1": 191.60446281433107,
-                            "y2": 443.8526682281494
+                            "extraction_method": "lattice",
+                            "selection_id": "R1503436112072",
+                            "x1": 320.7049455261231,
+                            "x2": 555.0948709106445,
+                            "y1": 161.45931407515974,
+                            "y2": 445.70360454146834,
+                            "width": 234.3899253845215,
+                            "height": 284.2442904663086
                         }
                     ]
   processing:
@@ -51,9 +49,9 @@
         mapping: subsidies_received
       - title: Income before tax
         mapping: profit_before_tax
-      - title: Deferred Taxes
+      - title: Deferred taxes
         mapping: deferred_tax
       - title: Corporate income tax
         mapping: corporate_tax_paid
-      - title: Financial headcount
+      - title: Financial headcount(**) as at 31 December
         mapping: full_time_equivalents

--- a/datapackage_pipelines_od4tj/pipelines/crd-iv/rbs/od4tj.source-spec.yaml
+++ b/datapackage_pipelines_od4tj/pipelines/crd-iv/rbs/od4tj.source-spec.yaml
@@ -43,6 +43,7 @@
                           "spec_index": 2
                         },
                         {
+                            "page": 2,
                             "extraction_method": "lattice",
                             "selection_id": "B1500972246959",
                             "x1": 62.00000204178505,
@@ -67,13 +68,13 @@
                         }
                       ]
   processing:
-    totals: 
+    totals:
       turnover: 15150
       profit_before_tax: 2643
       corporate_tax_paid: 179
       subsidies_received: 0
       full_time_equivalents: 94641
-      
+
   model:
     currency: gbp
     factor: 1000000

--- a/datapackage_pipelines_od4tj/pipelines/crd-iv/unicredit/od4tj.source-spec.yaml
+++ b/datapackage_pipelines_od4tj/pipelines/crd-iv/unicredit/od4tj.source-spec.yaml
@@ -4,8 +4,7 @@
   inputs:
     - url: https://www.unicreditgroup.eu/content/dam/unicreditgroup-eu/documents/en/investors/financial-reports/2014/CbC_Disclosure_Dec-31-2014-ENG-version-to-publish.pdf
       kind: pdf
-#      transpose: true
-#      skip_empty_cells: true
+      transpose: true
       parameters:
           dimensions: [
                         {

--- a/datapackage_pipelines_od4tj/processors/fix_numbers.py
+++ b/datapackage_pipelines_od4tj/processors/fix_numbers.py
@@ -65,6 +65,7 @@ def _remove_null_values(value):
     if isinstance(value, str):
         if value.strip() in (
             '-',
+            '–',
             '',
         ):
             value = None

--- a/datapackage_pipelines_od4tj/processors/tabula_resource.py
+++ b/datapackage_pipelines_od4tj/processors/tabula_resource.py
@@ -20,6 +20,24 @@ HEADER_SEARCH_ROWS = 10
 SCORE_THRESHOLD = 80
 
 
+def columns_for_headers(resource):
+    num_columns = len(resource[0])
+    columns_for_headers = {}
+    for header in parameters['headers']:
+        scores = [0] * num_columns
+        logging.info('LOOKING %r for title %r', header['mapping'], header['title'])
+        for row in resource:
+            for col in range(num_columns):
+                scores[col] += 1 if fuzz.partial_ratio(row[col], header['title']) > SCORE_THRESHOLD else 0
+        maxcol, maxscore = max(enumerate(scores), key=lambda x: x[1])
+        logging.info('HEADER %r got column %d', header['mapping'], maxcol)
+        assert maxcol not in columns_for_headers, \
+            "header %r and %r mapped to same column %d" % (header, columns_for_headers[maxcol], maxcol)
+        assert maxscore > 0, "Failed to find column for header %r" % header
+        columns_for_headers[maxcol] = header['mapping']
+    return columns_for_headers
+
+
 def fetch_pdf_file():
     url = parameters['url']
     delete_after_extract = False
@@ -45,56 +63,54 @@ def tabula_extract(extractor):
         'guess': False,
         'output_format': 'json',
     }
+    data = []
     dimensions = parameters['dimensions']
-    tabula_params['pages'] = dimensions['page']
-    # Warning: `spreadsheet=False` doesn't have the same effect as `nospreadsheet=True`
-    if dimensions.get('extraction_method') == 'spreadsheet':
-        tabula_params['spreadsheet'] = True
-    else:
-        tabula_params['nospreadsheet'] = True
-    tabula_params['area'] = [
-        dimensions['y1'],
-        dimensions['x1'],
-        dimensions['y2'],
-        dimensions['x2'],
-    ]
-    r = tabula.read_pdf(filename, **tabula_params)
-    data = r[0]['data']
-    data = [[cell['text'] for cell in row] for row in data]
-    if parameters['transpose']:
-        data = list(map(list, zip(*data)))
-
-    num_columns = len(data[0])
-    column_for_header = {}
-    for header in headers:
-        scores = [0] * num_columns
-        logging.info('LOOKING %r for title %r', header['mapping'], header['title'])
-        for row in data[:HEADER_SEARCH_ROWS]:
-            for col in range(num_columns):
-                scores[col] += 1 if fuzz.partial_ratio(row[col], header['title']) > SCORE_THRESHOLD else 0
-        maxcol, maxscore = max(enumerate(scores), key=lambda x: x[1])
-        logging.info('HEADER %r got column %d', header['mapping'], maxcol)
-        assert maxcol not in column_for_header, \
-            "header %r and %r mapped to same column %d" % (header, column_for_header[maxcol], maxcol)
-        assert maxscore > 0, "Failed to find column for header %r" % header
-        column_for_header[maxcol] = header['mapping']
-
-    data = [dict((column_for_header[i], x)
-                 for i, x in enumerate(row)
-                 if i in column_for_header)
-            for row in data]
-    for row in data:
-        row['url'] = parameters['url']
-        row['page'] = dimensions['page']
-    list(extractor)
+    for selection in dimensions:
+        tabula_params['pages'] = selection['page']
+        # Warning: `spreadsheet=False` doesn't have the same effect as `nospreadsheet=True`
+        if selection.get('extraction_method') == 'spreadsheet':
+            tabula_params['spreadsheet'] = True
+        else:
+            tabula_params['nospreadsheet'] = True
+        tabula_params['area'] = [
+            selection['y1'],
+            selection['x1'],
+            selection['y2'],
+            selection['x2'],
+        ]
+        r = tabula.read_pdf(parameters['url'], **tabula_params)
+        selection_data = r[0]['data']
+        selection_data = [[cell['text'] for cell in row] for row in selection_data]
+        if parameters['transpose']:
+            selection_data = list(map(list, zip(*selection_data)))
+        data.extend(selection_data)
     return data
+
+
+def add_headers(resource, extracted_headers):
+    new_resource = []
+    for row in resource:
+        new_row = {}
+        for index, value in enumerate(row):
+            if index in extracted_headers:
+                new_row[extracted_headers[index]] = value
+        new_row['url'] = parameters['url']
+        new_resource.append(new_row)
+    return new_resource
+
+
+def process_resource():
+    resource_data = tabula_extract(fetch_pdf_file())
+    resource_headers = columns_for_headers(resource_data)
+    return add_headers(resource_data, resource_headers)
 
 
 def modify_datapackage(dp):
     fields = parameters['headers']
+    filename = os.path.splitext(os.path.basename(parameters['url']))[0]
     resource = {
-        'name': 'tabula-' + parameters['dimensions']['selection_id'].lower(),
-        'path': 'data/{}.csv'.format(parameters['dimensions']['selection_id']),
+        'name': 'tabula-{}'.format(filename.lower()),
+        'path': 'data/{}.csv'.format(filename),
         'schema': {
             'fields': [
                 {
@@ -107,11 +123,9 @@ def modify_datapackage(dp):
     }
     resource['schema']['fields'].extend([
         {'name': 'url', 'type': 'string'},
-        {'name': 'page', 'type': 'integer'},
     ])
     dp['resources'].append(resource)
     return dp
 
 
-spew(modify_datapackage(dp),
-     itertools.chain(res_iter, [tabula_extract(fetch_pdf_file())]))
+spew(modify_datapackage(dp), itertools.chain(res_iter, [process_resource()]))


### PR DESCRIPTION
Currently the logic for guessing titles runs for every selection. This works for cases where there are titles for all fields in every selection. However, some tables miss the title for a column (E.g. `country`) and we decided that users will give a value from that column as identifier instead of the title.

If we guess titles for each selection the guessing will fail:
- for any selection that doesn't include the value that replaces the title
- for any selection that doesn't include titles

There is no reason to guess the titles for each selection because they should all be part of the same table. Also, it's hard to ensure that users will give us the value that replaces the title from a certain selection (e.g. first ) which is another reason to run title-guessing on the entire table.

So in this PR I changed the `tabula-resource` processor to merge the result of selections parsing into a table and run title guessing on it.

I also made some small fixes to other pipelines and processors.

Despite these changes there are still title errors left caused by #31.
.